### PR TITLE
removed unreachable tokeInfo error check block.

### DIFF
--- a/src/com/google/plus/samples/verifytoken/Verify.java
+++ b/src/com/google/plus/samples/verifytoken/Verify.java
@@ -57,10 +57,6 @@ public class Verify {
    */
   private static final String CLIENT_ID = "YOUR_CLIENT_ID";
   /**
-   * Replace this with the client secret you got from the Google APIs console.
-   */
-  private static final String CLIENT_SECRET = "YOUR_CLIENT_SECRET";
-  /**
    * Optionally replace this with your application's name.
    */
   private static final String APPLICATION_NAME = "Google+ Java Token Verification";
@@ -145,12 +141,7 @@ public class Verify {
                 TRANSPORT, JSON_FACTORY, credential).build();
             Tokeninfo tokenInfo = oauth2.tokeninfo()
                 .setAccessToken(accessToken).execute();
-            if (tokenInfo.containsKey("error")) {
-              // This is not a valid token.
-              accessStatus.setValid(false);
-              accessStatus.setId("");
-              accessStatus.setMessage("Invalid Access Token.");
-            } else if (!tokenInfo.getIssuedTo().equals(CLIENT_ID)) {
+            if (!tokenInfo.getIssuedTo().equals(CLIENT_ID)) {
               // This is not meant for this app. It is VERY important to check
               // the client ID in order to prevent man-in-the-middle attacks.
               accessStatus.setValid(false);


### PR DESCRIPTION
The following ` if (tokenInfo.containsKey("error"))` in Verify.java is unreachable and slightly misleading. Because when calling

    Tokeninfo tokenInfo = oauth2.tokeninfo().setAccessToken(accessToken).execute()

With an invalid token (such as an expired one), the SDK will always throw an Exception instead of returning a Tokeinfo object:

    com.google.api.client.googleapis.json.GoogleJsonResponseException: 400 Bad Request
        at com.google.api.client.googleapis.json.GoogleJsonResponseException.from(GoogleJsonResponseException.java:145)

The `GoogleJsonResponseException` is quite understandable. You can verify by calling the API directly without using the SDK: `https://www.googleapis.com/oauth2/v1/tokeninfo?access_token=`. If a invalid/expired token is used, the error response can't be parsed into a Tokeninfo object:

    {
        error: "invalid_token",
        error_description: "Invalid Value"
    }

Therefore the developer really shouldn't be checking for errors in the Tokeninfo but instead rely the IOException catch block. 